### PR TITLE
Bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.4
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.4
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -28,25 +28,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.4
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.4
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.4
         with:
           command: "readme"
         env:
@@ -57,12 +57,12 @@ jobs:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.4
         with:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: peaceiris/actions-gh-pages@v4.1.0
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -28,17 +28,17 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.4
         with:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: peaceiris/actions-gh-pages@v4.1.0
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.4
         with:
           command: "readme"
         env:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.4
         with:
           command: "update"
         env:


### PR DESCRIPTION
## Summary

GitHub is deprecating Node 20 as an Actions runtime (Node 20 reached EOL April 2026; runners switch to Node 24 by default on June 16 2026; forced fall 2026). This bumps the actions in our workflows that still declare a `node20` runtime to releases that run on `node24`.

| Action (was) | Now | Runtime |
|---|---|---|
| `actions/checkout@v4` | `@v5` | node24 |
| `upptime/uptime-monitor@v1.41.0` | `@v1.42.4` | node24 |
| `peaceiris/actions-gh-pages@v4` | `@v4.1.0` | node24 |

Applied across all 7 workflow files.

## Notes

- `benc-uk/workflow-dispatch@v1` already resolves to a node24 release — left unchanged.
- `upptime/updates@master` pins a moving ref (currently node12) and is only invoked by the now-removed Updates CI — left unchanged.
- These files carry the Upptime "Do not edit this file directly!" banner, but the `update-template` workflow was removed (commit 0286d27), so nothing will overwrite these edits.

Source: [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)